### PR TITLE
Accept and manage `loading` being passed in

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -23,7 +23,7 @@ export default class Model {
 
     // Build a list of all possible operations, then check if
     // it's been set in options.
-    let operations = ['list', 'create', 'detail', 'update', 'remove'];
+    let operations = ['list', 'create', 'detail', 'update', 'remove', 'options'];
     for( const field of this.iterManyToMany() ) {
       operations.push( field + 'Add' );
       operations.push( field + 'Remove' );


### PR DESCRIPTION
Passing in `loading` to a `DBComponent` now stalls the load until it's
set to false.

Fixes #15