### PR TITLE
Fix/modelform options format

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-node-externals": "^1.5.4"
   },
   "dependencies": {
-    "js-tinyapi": "^0.0.4",
+    "js-tinyapi": "^0.0.10",
     "react": "^16.2.0",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",

--- a/src/components/forms/model-form.jsx
+++ b/src/components/forms/model-form.jsx
@@ -47,8 +47,7 @@ class ModelForm extends Component {
       ...(fieldProps[fieldName] || {})
     }
     if( field.get( 'choices', undefined ) ) {
-      props.options = field.get( 'choices' ).toJS()
-      props.options = Object.keys( props.options ).map( v => ({value: v, label: props.options[v]}) )
+      props.options = field.get( 'choices' ).toJS().map( v => ({value: v.value, label: v.display_name}) )
     }
     return React.createElement(
       cls,

--- a/src/components/forms/model-form.jsx
+++ b/src/components/forms/model-form.jsx
@@ -16,9 +16,6 @@ class ModelForm extends Component {
     const isFK = model.fieldIsForeignKey( fieldName )
     if( isFK ) {
       type = 'foreignkey'
-      if( value ) {
-        value = db.get( value )
-      }
     }
     else {
       type = field.get( 'type' )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2261,9 +2261,9 @@ js-cookie@^2.1.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
 
-js-tinyapi@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/js-tinyapi/-/js-tinyapi-0.0.4.tgz#3cd38894600e60062ce977fb0334d80892c77786"
+js-tinyapi@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/js-tinyapi/-/js-tinyapi-0.0.10.tgz#6c1949a011bccc344ed03032bc9d1b92bd2fbe3d"
   dependencies:
     js-cookie "^2.1.3"
 


### PR DESCRIPTION
New models format returns choices as an array of value, display_name
This updates ModelForm to parse them correctly to make sure Select components work as intended